### PR TITLE
Change generated EntityDescriptor ID with hash of content 

### DIFF
--- a/src/main/resources/META-INF/jboss-deployment-structure.xml
+++ b/src/main/resources/META-INF/jboss-deployment-structure.xml
@@ -5,6 +5,7 @@
             <module name="org.keycloak.keycloak-saml-core"/>
             <module name="org.keycloak.keycloak-services"/>
             <module name="org.keycloak.keycloak-saml-core-public"/>
+            <module name="org.apache.commons.codec"/>
         </dependencies>
     </deployment>
 </jboss-deployment-structure>

--- a/src/test/resources/metadata/expected_metadata_private_SP.xml
+++ b/src/test/resources/metadata/expected_metadata_private_SP.xml
@@ -1,11 +1,11 @@
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="${xmlunit.matchesRegex(^ID_[0-9a-f-]{36}$)}"
+                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="${xmlunit.matchesRegex(^ID_[0-9a-f-]{32}$)}"
                      entityID="https://keycloak.company.name.it">
   <dsig:Signature xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
     <dsig:SignedInfo>
       <dsig:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
       <dsig:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
-      <dsig:Reference URI="${xmlunit.matchesRegex(^#ID_[0-9a-f-]{36}$)}">
+      <dsig:Reference URI="${xmlunit.matchesRegex(^#ID_[0-9a-f-]{32}$)}">
         <dsig:Transforms>
           <dsig:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
           <dsig:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />

--- a/src/test/resources/metadata/expected_metadata_public_SP.xml
+++ b/src/test/resources/metadata/expected_metadata_public_SP.xml
@@ -1,11 +1,11 @@
 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
-                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="${xmlunit.matchesRegex(^ID_[0-9a-f-]{36}$)}"
+                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="${xmlunit.matchesRegex(^ID_[0-9a-f-]{32}$)}"
                      entityID="https://keycloak.company.name.it">
   <dsig:Signature xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
     <dsig:SignedInfo>
       <dsig:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
       <dsig:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
-      <dsig:Reference URI="${xmlunit.matchesRegex(^#ID_[0-9a-f-]{36}$)}">
+      <dsig:Reference URI="${xmlunit.matchesRegex(^#ID_[0-9a-f-]{32}$)}">
         <dsig:Transforms>
           <dsig:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
           <dsig:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />


### PR DESCRIPTION
Change generation of EntitiyDescriptor ID of generated metadata file.  
Using hash of metadata file content instead of new random uuid for each request.
This results in returning same metadata for each GET of endpoint if the configuration does not change.   