### PR TITLE
Fix: substring index is wrong

### DIFF
--- a/src/main/java/org/keycloak/broker/spid/metadata/extensions/SpidBillingContactTypePrivateSP.java
+++ b/src/main/java/org/keycloak/broker/spid/metadata/extensions/SpidBillingContactTypePrivateSP.java
@@ -30,7 +30,7 @@ public class SpidBillingContactTypePrivateSP extends SpidBillingContactType {
             logger.errorf("Invalid VAT number % ", config.getVatNumber());
         } else {
             createElement("fpa:IdPaese", config.getVatNumber().substring(0, 2)).ifPresent(vatFiscalCode::appendChild);
-            createElement("fpa:IdCodice", config.getVatNumber().substring(3, 13)).ifPresent(vatFiscalCode::appendChild);
+            createElement("fpa:IdCodice", config.getVatNumber().substring(2, 13)).ifPresent(vatFiscalCode::appendChild);
         }
         personalData.appendChild(vatFiscalCode);
 


### PR DESCRIPTION
left range of VAT number is wrong, it cuts the first digit
VAT number is 

- country code 2 letters
- 11 digits

with the substring 3-13 the first digit will be lost.