### PR TITLE
Fix md5hex

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,6 @@
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <mockito.version>4.3.1</mockito.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
         <resteasy.version>6.2.7.Final</resteasy.version>
     </properties>
 
@@ -139,7 +137,7 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <release>11</release>
+                    <release>17</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/keycloak/broker/spid/metadata/SpidSpMetadataResourceProvider.java
+++ b/src/main/java/org/keycloak/broker/spid/metadata/SpidSpMetadataResourceProvider.java
@@ -58,6 +58,7 @@ import java.security.KeyPair;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
+import java.util.HexFormat;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -353,11 +354,7 @@ public class SpidSpMetadataResourceProvider implements RealmResourceProvider {
     {
         try {
             byte[] bytes = MessageDigest.getInstance("MD5").digest(data.getBytes(StandardCharsets.UTF_8));
-            StringBuilder sb = new StringBuilder(32);
-            for (byte b: bytes) {
-                sb.append(String.format("%02x", b));
-            }
-            return sb.toString();
+            return HexFormat.of().formatHex(bytes);
         }
         catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/keycloak/broker/spid/metadata/SpidSpMetadataResourceProvider.java
+++ b/src/main/java/org/keycloak/broker/spid/metadata/SpidSpMetadataResourceProvider.java
@@ -52,7 +52,6 @@ import org.keycloak.protocol.saml.mappers.SamlMetadataDescriptorUpdater;
 import org.keycloak.services.resource.RealmResourceProvider;
 
 import java.io.StringWriter;
-import java.math.BigInteger;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
@@ -351,7 +350,11 @@ public class SpidSpMetadataResourceProvider implements RealmResourceProvider {
     {
         try {
             byte[] bytes = MessageDigest.getInstance("MD5").digest(data.getBytes(StandardCharsets.UTF_8));
-            return new BigInteger(1, bytes).toString(16);
+            StringBuilder sb = new StringBuilder(32);
+            for (byte b: bytes) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
         }
         catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Come anticipato negli issues, ho modificato il metodo md5hex per fare in modo che il consistent id sia generato nel formato accettato dai test unitari.