### PR TITLE
Use the official configuration client project

### DIFF
--- a/kc-spid-compose/Makefile
+++ b/kc-spid-compose/Makefile
@@ -21,7 +21,7 @@ create-configuration-client-docker-image:
 #Creazione directory temporanea per dowload dei sorgenti
 	mkdir ${PWD}/tmp-docker-configuration-client
 	cd ${PWD}/tmp-docker-configuration-client
-	git clone https://github.com/polifr/keycloak-spid-provider-configuration-client.git
+	git clone https://github.com/nicolabeghin/keycloak-spid-provider-configuration-client.git
 	docker build --tag spidclient:latest-KC ./keycloak-spid-provider-configuration-client
 	cd -
 # Cancellazione directory temporanea


### PR DESCRIPTION
I updated the Makefile so that it downloads the sources from the official configuration client project instead of my fork, since the pull request introducing the "first broker login" name change has now been merged.
