### PR TITLE
Configuration client docker image usage and workflow db matrix for testing

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up JDK
       uses: actions/setup-java@v5
@@ -58,7 +58,7 @@ jobs:
       
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Verify Docker
         run: |
@@ -75,7 +75,7 @@ jobs:
           make clean init
 
       - name: Download provider jar
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: spid-provider.jar
           path: kc-spid-compose/provider
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: spid-sp-test-report
           path: |
@@ -102,7 +102,7 @@ jobs:
           docker logs spid-nginx > docker-logs/nginx.log 2>&1 || true
           docker logs spid-${{ matrix.db }} > docker-logs/${{ matrix.db }}.log 2>&1 || true
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: docker-logs

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,11 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v5
       with:
+        distribution: temurin
         java-version: 21
+
+    - name: Check JDK version
+      run: java --version
 
     - name: Cache Maven packages
       uses: actions/cache@v6

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -74,16 +74,16 @@ jobs:
         run: |
           make clean init
 
-      - name: Run kc-spid-compose tests
-        working-directory: kc-spid-compose
-        run: |
-          make compose-${{ matrix.db }} _sleep run-configuration-client test-responses
-
       - name: Download provider jar
         uses: actions/download-artifact@v4
         with:
           name: spid-provider.jar
           path: kc-spid-compose/provider
+
+      - name: Run kc-spid-compose tests
+        working-directory: kc-spid-compose
+        run: |
+          make compose-${{ matrix.db }} _sleep run-configuration-client test-responses
 
       - name: Upload reports
         if: always()

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,110 @@
+name: Builds JAR and runs test with docker-compose
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK
+      uses: actions/setup-java@v5
+      with:
+        java-version: 21
+
+    - name: Cache Maven packages
+      uses: actions/cache@v6
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+
+    - name: Build with Maven
+      run: mvn --batch-mode --update-snapshots package
+
+    - uses: actions/upload-artifact@v7
+      with:
+        name: spid-provider.jar
+        path: target/spid-provider.jar
+
+    - name: Release
+      uses: softprops/action-gh-release@v3
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: target/spid-provider.jar
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test-compose:
+    name: Test on docker-compose
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build
+
+    strategy:
+      fail-fast: false
+      matrix:
+        db: [mariadb, mysql, postgres]
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify Docker
+        run: |
+          docker version
+          docker compose version
+
+      - name: Verify connectivity
+        run: |
+          curl -L -I https://indicepa.gov.it:443
+
+      - name: Clean and init test infrastructure
+        working-directory: kc-spid-compose
+        run: |
+          make clean init
+
+      - name: Run kc-spid-compose tests
+        working-directory: kc-spid-compose
+        run: |
+          make compose-${{ matrix.db }} _sleep run-configuration-client test-responses
+
+      - name: Download provider jar
+        uses: actions/download-artifact@v4
+        with:
+          name: spid-provider.jar
+          path: kc-spid-compose/provider
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spid-sp-test-report
+          path: |
+            kc-spid-compose/tests/report/**
+            kc-spid-compose/tests/dumps/**
+
+      - name: Collect docker logs
+        if: always()
+        run: |
+          mkdir -p docker-logs
+          docker logs spid-keycloak > docker-logs/keycloak.log 2>&1 || true
+          docker logs spid-nginx > docker-logs/nginx.log 2>&1 || true
+          docker logs spid-${{ matrix.db }} > docker-logs/${{ matrix.db }}.log 2>&1 || true
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: docker-logs
+          path: docker-logs
+
+      - name: Cleanup
+        if: always()
+        working-directory: kc-spid-compose
+        run: make clean

--- a/.github/workflows/kc-spid-compose-test.yml
+++ b/.github/workflows/kc-spid-compose-test.yml
@@ -16,6 +16,7 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: false
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,6 +12,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    if: false
 
     steps:
     - uses: actions/checkout@v2

--- a/kc-spid-compose/Makefile
+++ b/kc-spid-compose/Makefile
@@ -2,6 +2,10 @@
 .EXPORT_ALL_VARIABLES:
 SPID_KC_VERSION := $(shell sed -n 's:.*<keycloak.version>\(.*\)</keycloak.version>.*:\1:p' ../pom.xml)
 NOW := $(shell date +"%Y%m%d_%H%M%S")
+CONFIGURATION_CLIENT_IMAGE := ghcr.io/polifr/keycloak-spid-provider-configuration-client
+CONFIGURATION_CLIENT_VERSION := latest
+SPID_SP_TEST_IMAGE := italia/spid-sp-test
+SPID_SP_TEST_VERSION := 0.9.0-KC
 
 .ONESHELL:
 
@@ -47,7 +51,7 @@ create-spid-sp-test-docker-image:
 	sed -i "s#<ds:X509Certificate />#<ds:X509Certificate>$$(grep -v CERTIFICATE ./spid-sp-test/src/spid_sp_test/responses/certificates/test_public.cert | tr -d '\n')</ds:X509Certificate>#" \
 		./spid-sp-test/src/spid_sp_test/responses/settings.py
 
-	docker build --tag italia/spid-sp-test:0.9.0-KC ./spid-sp-test
+	docker build --tag $(SPID_SP_TEST_IMAGE):$(SPID_SP_TEST_VERSION) ./spid-sp-test
 
 	cd -
 
@@ -63,7 +67,7 @@ create-spid-sp-test-metadata-certificates:
 	docker run --net=host --rm \
 		--user "$(id -u):$(id -g)" \
 		-v "${PWD}/certificates/spid-sp-test-idp:/spid:rw" \
-		--entrypoint "spid-compliant-certificates" -t italia/spid-sp-test:0.9.0-KC generator \
+		--entrypoint "spid-compliant-certificates" -t $(SPID_SP_TEST_IMAGE):$(SPID_SP_TEST_VERSION) generator \
 		--key-size 3072 --common-name "agid.gov.it" --days 7650 --entity-id https://localhost:8443 \
 		--locality-name Roma --org-id "PA:IT-c_h501" --org-name "AgID TEST" --sector public	
 
@@ -78,7 +82,7 @@ create-spid-sp-test-metadata-certificates:
 		--user "$(id -u):$(id -g)" \
 		-e IDP_CERT_PATH=/spid/ipd-certs \
 		-v "${PWD}/certificates/spid-sp-test-idp:/spid/ipd-certs:ro" \
-		italia/spid-sp-test:0.9.0-KC --idp-metadata \
+		$(SPID_SP_TEST_IMAGE):$(SPID_SP_TEST_VERSION) --idp-metadata \
 		| sed '/^[[:space:]]*</!d' \
 		| sed 's/WantAuthnRequestsSigned="false"/WantAuthnRequestsSigned="true" WantAssertionsSigned="false"/' \
 		> ${PWD}/tests/spid-sp-test.xml
@@ -91,7 +95,7 @@ run-configuration-client:
 		--user "$(id -u):$(id -g)" \
 		-v "${PWD}/configuration-client:/opt/mount:rw" \
 		--rm \
-		--entrypoint cp ghcr.io/polifr/keycloak-spid-provider-configuration-client:latest /usr/src/app/.env-example /opt/mount/.env-example
+		--entrypoint cp $(CONFIGURATION_CLIENT_IMAGE):$(CONFIGURATION_CLIENT_VERSION) /usr/src/app/.env-example /opt/mount/.env-example
 	cat ${PWD}/configuration-client/.env-example \
 		| sed 's,createSpidSpTestIdP = false,createSpidSpTestIdP = true,g' \
 		| sed 's,https://yourdomain.com/spid-sp-test.xml,https://spid-nginx:443/spid-sp-test.xml,g' \
@@ -103,7 +107,7 @@ run-configuration-client:
 		-t --rm \
 		-v "${PWD}/configuration-client/.env:/usr/src/app/.env:ro" \
 		-v "${PWD}/configuration-client/log:/usr/src/app/log:rw" \
-		ghcr.io/polifr/keycloak-spid-provider-configuration-client:latest
+		$(CONFIGURATION_CLIENT_IMAGE):$(CONFIGURATION_CLIENT_VERSION)
 
 
 # Test commands
@@ -115,7 +119,7 @@ test-metadata:
 		-e IDP_CERT_PATH=/spid/ipd-certs \
 		-v "${PWD}/certificates/spid-sp-test-idp:/spid/ipd-certs" \
 		-v "${PWD}/tests/report/$(NOW)_metadata:/spid/html_report:rw" \
-		italia/spid-sp-test:0.9.0-KC \
+		$(SPID_SP_TEST_IMAGE):$(SPID_SP_TEST_VERSION) \
 		--metadata-url "https://localhost:8443/auth/realms/spid/spid-sp-metadata" \
 		--extra --report_format html --report-output-file html_report/
 
@@ -126,7 +130,7 @@ test-authn:
 		-e IDP_CERT_PATH=/spid/ipd-certs \
 		-v "${PWD}/certificates/spid-sp-test-idp:/spid/ipd-certs" \
 		-v "${PWD}/tests/report/$(NOW)_authn:/spid/html_report:rw" \
-		italia/spid-sp-test:0.9.0-KC \
+		$(SPID_SP_TEST_IMAGE):$(SPID_SP_TEST_VERSION) \
 		--metadata-url "https://localhost:8443/auth/realms/spid/spid-sp-metadata" \
 		--authn-url "https://localhost:8443/auth/realms/spid/protocol/openid-connect/auth?client_id=account&scope=openid&response_type=code&redirect_uri=https://localhost:8443/auth/realms/spid/account&state=12345&kc_idp_hint=spid-spid-sp-test" \
 		--extra --report_format html --report-output-file html_report/
@@ -140,7 +144,7 @@ test-responses:
 		-v "${PWD}/certificates/spid-sp-test-idp:/spid/ipd-certs" \
 		-v "${PWD}/tests/report/$(NOW)_responses:/spid/html_report:rw" \
 		-v "${PWD}/tests/dumps/$(NOW)_responses:/spid/dumps:rw" \
-		italia/spid-sp-test:0.9.0-KC \
+		italia/spid-sp-test:$(SPID_SP_TEST_VERSION) \
 		--metadata-url "https://localhost:8443/auth/realms/spid/spid-sp-metadata" \
 		--authn-url "https://localhost:8443/auth/realms/spid/protocol/openid-connect/auth?client_id=account&scope=openid&response_type=code&redirect_uri=https://localhost:8443/auth/realms/spid/account&state=12345&kc_idp_hint=spid-spid-sp-test" \
 		--extra --report_format html --report-output-file html_report/ \

--- a/kc-spid-compose/Makefile
+++ b/kc-spid-compose/Makefile
@@ -15,18 +15,6 @@ build-provider-jar:
 	make -C ${PWD}/.. build
 	cp ${PWD}/../target/spid-provider.jar ${PWD}/provider/spid-provider.jar
 
-create-configuration-client-docker-image:
-# Cancellazione directory temporanea
-	rm -rf ${PWD}/tmp-docker-configuration-client
-#Creazione directory temporanea per dowload dei sorgenti
-	mkdir ${PWD}/tmp-docker-configuration-client
-	cd ${PWD}/tmp-docker-configuration-client
-	git clone https://github.com/nicolabeghin/keycloak-spid-provider-configuration-client.git
-	docker build --tag spidclient:latest-KC ./keycloak-spid-provider-configuration-client
-	cd -
-# Cancellazione directory temporanea
-	rm -rf ${PWD}/tmp-docker-configuration-client
-
 create-self-signed-certificates:
 # Key and crt files generation for keycloak
 	rm -rf ${PWD}/certificates/keycloak-server.key ${PWD}/certificates/keycloak-server.crt
@@ -103,7 +91,7 @@ run-configuration-client:
 		--user "$(id -u):$(id -g)" \
 		-v "${PWD}/configuration-client:/opt/mount:rw" \
 		--rm \
-		--entrypoint cp spidclient:latest-KC /usr/src/app/.env-example /opt/mount/.env-example
+		--entrypoint cp ghcr.io/polifr/keycloak-spid-provider-configuration-client:latest /usr/src/app/.env-example /opt/mount/.env-example
 	cat ${PWD}/configuration-client/.env-example \
 		| sed 's,createSpidSpTestIdP = false,createSpidSpTestIdP = true,g' \
 		| sed 's,https://yourdomain.com/spid-sp-test.xml,https://spid-nginx:443/spid-sp-test.xml,g' \
@@ -115,7 +103,7 @@ run-configuration-client:
 		-t --rm \
 		-v "${PWD}/configuration-client/.env:/usr/src/app/.env:ro" \
 		-v "${PWD}/configuration-client/log:/usr/src/app/log:rw" \
-		spidclient:latest-KC
+		ghcr.io/polifr/keycloak-spid-provider-configuration-client:latest
 
 
 # Test commands
@@ -170,7 +158,7 @@ clean: reset-mariadb reset-mysql reset-postgres
 
 # Common entities configuration
 
-init: create-configuration-client-docker-image create-self-signed-certificates create-spid-sp-test-docker-image create-spid-sp-test-metadata-certificates
+init: create-self-signed-certificates create-spid-sp-test-docker-image create-spid-sp-test-metadata-certificates
 
 
 


### PR DESCRIPTION
I modified the `Makefile` to use a configuration client docker image that is build using the github action that is currently proposed in the PR of the `keycloak-spid-provider-configuration-client`, it seems to work.
Moreover I modified the workflow of the project, merging the build and the test jobs into a single file that first builds the provider jar, and then makes the test, using the already build jar. In this, I expanded the strategy to use a matrix so the provider is test on three different databases (mysql, mariadb and postgres).
The two "old" workflows are still there, but I disabled them (currently, they are skipped).
Let me know what you think about this changes, I think there is still room to optimizations (e.g. some common steps of the tests).
Thanks