### PR TITLE
Add SPID validation for GrantedAttributeAuthority / GrantToken

### DIFF
--- a/src/main/java/org/keycloak/broker/spid/SpidChecks.java
+++ b/src/main/java/org/keycloak/broker/spid/SpidChecks.java
@@ -466,6 +466,11 @@ public class SpidChecks {
             }
         }
 
+        String grantedAttributeAuthorityValidationError = validateGrantedAttributeAuthority(documentElement);
+        if (grantedAttributeAuthorityValidationError != null) {
+            return grantedAttributeAuthorityValidationError;
+        }
+
         return null;
     }
 
@@ -504,6 +509,44 @@ public class SpidChecks {
             default:
                 return "SpidSamlCheck_nr97";
         }
+    }
+
+    String validateGrantedAttributeAuthority(Element documentElement) {
+        Element extensionsElement = getDirectChild(documentElement, "Extensions");
+        if (extensionsElement == null) {
+            return null;
+        }
+
+        Element grantedAttributeAuthorityElement = getDirectChild(extensionsElement, "GrantedAttributeAuthority");
+        if (grantedAttributeAuthorityElement == null) {
+            return null;
+        }
+
+        NodeList childNodes = grantedAttributeAuthorityElement.getChildNodes();
+        boolean atLeastOneGrantTokenOccurrence = false;
+
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node node = childNodes.item(i);
+
+            if (node.getNodeType() == Node.ELEMENT_NODE && "GrantToken".equals(node.getLocalName())) {
+                atLeastOneGrantTokenOccurrence = true;
+                Element grantTokenElement = (Element) node;
+
+                if (!grantTokenElement.hasAttribute("Destination")) {
+                    return "SpidSamlCheck_MissingGrantTokenDestination";
+                }
+
+                if (grantTokenElement.getAttribute("Destination").trim().isEmpty()) {
+                    return "SpidSamlCheck_EmptyGrantTokenDestination";
+                }
+            }
+        }
+
+        if (!atLeastOneGrantTokenOccurrence) {
+            return "SpidSamlCheck_MissingGrantToken";
+        }
+
+        return null;
     }
 
     private boolean hasNamedChild(Element element) {

--- a/src/main/resources/theme-resources/messages/messages_en.properties
+++ b/src/main/resources/theme-resources/messages/messages_en.properties
@@ -119,6 +119,9 @@ SpidSamlCheck_nr98=AttributeStatement element present, but Attribute sub-element
 SpidSamlCheck_nr99=AttributeStatement element present, but Attribute sub-element is empty (SPID check nr99)
 SpidSamlCheck_nr100=Assertion signed with different certificate (SPID check nr100)
 SpidSamlCheck_nr103=Attribute set sent different from the one requested (SPID check nr103)
+SpidSamlCheck_EmptyGrantTokenDestination=GrantedAttributeAuthority GrantToken Destination attribute is empty
+SpidSamlCheck_MissingGrantTokenDestination=GrantedAttributeAuthority GrantToken Destination attribute is missing
+SpidSamlCheck_MissingGrantToken=GrantedAttributeAuthority element does not contain any GrantToken element
 
 ############################
 # SAML Config translations #

--- a/src/main/resources/theme-resources/messages/messages_it.properties
+++ b/src/main/resources/theme-resources/messages/messages_it.properties
@@ -119,6 +119,9 @@ SpidSamlCheck_nr98=Elemento AttributeStatement presente, ma sottoelemento Attri
 SpidSamlCheck_nr99=Elemento AttributeStatement presente, ma sottoelemento Attribute non specificato (SPID check nr99)
 SpidSamlCheck_nr100=Assertion firmata con certificato diverso (SPID check nr100)
 SpidSamlCheck_nr103=Set di attributi inviato diverso da quello richiesto (SPID check nr103)
+SpidSamlCheck_EmptyGrantTokenDestination=Attributo Destination di GrantToken in GrantedAttributeAuthority non specificato
+SpidSamlCheck_MissingGrantTokenDestination=Attributo Destination di GrantToken in GrantedAttributeAuthority mancante
+SpidSamlCheck_MissingGrantToken=Elemento GrantedAttributeAuthority senza alcun elemento GrantToken
 
 ############################
 # SAML Config translations #

--- a/src/test/java/org/keycloak/broker/spid/SpidChecksTest.java
+++ b/src/test/java/org/keycloak/broker/spid/SpidChecksTest.java
@@ -1,0 +1,90 @@
+package org.keycloak.broker.spid;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.StringReader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class SpidChecksTest {
+
+    private SpidChecks spidChecks;
+
+    @BeforeEach
+    void setUp() {
+        spidChecks = new SpidChecks(new SpidIdentityProviderConfig());
+    }
+
+    @Test
+    void validateGrantedAttributeAuthority_shouldPassWhenExtensionsIsMissing() throws Exception {
+        assertNull(spidChecks.validateGrantedAttributeAuthority(parseResponseElement("")));
+    }
+
+    @Test
+    void validateGrantedAttributeAuthority_shouldFailWhenGrantTokenIsMissing() throws Exception {
+        String extensionsXml = "<samlp:Extensions>"
+            + "<spid:GrantedAttributeAuthority xmlns:spid=\"https://spid.gov.it/saml-extensions\"/>"
+            + "</samlp:Extensions>";
+
+        assertEquals(
+            "SpidSamlCheck_MissingGrantToken",
+            spidChecks.validateGrantedAttributeAuthority(parseResponseElement(extensionsXml))
+        );
+    }
+
+    @Test
+    void validateGrantedAttributeAuthority_shouldFailWhenGrantTokenDestinationIsMissing() throws Exception {
+        String extensionsXml = "<samlp:Extensions>"
+            + "<spid:GrantedAttributeAuthority xmlns:spid=\"https://spid.gov.it/saml-extensions\">"
+            + "<spid:GrantToken>token</spid:GrantToken>"
+            + "</spid:GrantedAttributeAuthority>"
+            + "</samlp:Extensions>";
+
+        assertEquals(
+            "SpidSamlCheck_MissingGrantTokenDestination",
+            spidChecks.validateGrantedAttributeAuthority(parseResponseElement(extensionsXml))
+        );
+    }
+
+    @Test
+    void validateGrantedAttributeAuthority_shouldFailWhenGrantTokenDestinationIsEmpty() throws Exception {
+        String extensionsXml = "<samlp:Extensions>"
+            + "<spid:GrantedAttributeAuthority xmlns:spid=\"https://spid.gov.it/saml-extensions\">"
+            + "<spid:GrantToken Destination=\"  \">token</spid:GrantToken>"
+            + "</spid:GrantedAttributeAuthority>"
+            + "</samlp:Extensions>";
+
+        assertEquals(
+            "SpidSamlCheck_EmptyGrantTokenDestination",
+            spidChecks.validateGrantedAttributeAuthority(parseResponseElement(extensionsXml))
+        );
+    }
+
+    @Test
+    void validateGrantedAttributeAuthority_shouldPassWhenGrantTokenDestinationIsValid() throws Exception {
+        String extensionsXml = "<samlp:Extensions>"
+            + "<spid:GrantedAttributeAuthority xmlns:spid=\"https://spid.gov.it/saml-extensions\">"
+            + "<spid:GrantToken Destination=\"https://sp.example.it/auth/realms/test/broker/spid/endpoint\">token</spid:GrantToken>"
+            + "</spid:GrantedAttributeAuthority>"
+            + "</samlp:Extensions>";
+
+        assertNull(spidChecks.validateGrantedAttributeAuthority(parseResponseElement(extensionsXml)));
+    }
+
+    private Element parseResponseElement(String responseChildrenXml) throws Exception {
+        String responseXml = "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\">"
+            + responseChildrenXml
+            + "</samlp:Response>";
+
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        return factory.newDocumentBuilder()
+            .parse(new InputSource(new StringReader(responseXml)))
+            .getDocumentElement();
+    }
+}


### PR DESCRIPTION
Fixes #127 

Some SPID validator cases around `GrantedAttributeAuthority` were not enforced by the provider, so malformed responses could still pass broker-side checks. This change extends SPID response validation to cover the missing OAS3 constraints on `GrantToken`.

- **Response validation**
  - Added checks in `SpidChecks` for `Response/Extensions/GrantedAttributeAuthority`:
    - fail when `GrantToken` is missing
    - fail when `GrantToken@Destination` is missing
    - fail when `GrantToken@Destination` is present but blank
  - Introduced dedicated error codes:
    - `SpidSamlCheck_MissingGrantToken`
    - `SpidSamlCheck_MissingGrantTokenDestination`
    - `SpidSamlCheck_EmptyGrantTokenDestination`

- **Error message mapping**
  - Added localized messages for the new error codes in:
    - `messages_en.properties`
    - `messages_it.properties`

- **Targeted unit coverage**
  - Added `SpidChecksTest` focused on the new `GrantedAttributeAuthority` scenarios to keep behavior explicit and regression-safe.

```java
if (!grantTokenElement.hasAttribute("Destination")) {
    return "SpidSamlCheck_MissingGrantTokenDestination";
}
if (grantTokenElement.getAttribute("Destination").trim().isEmpty()) {
    return "SpidSamlCheck_EmptyGrantTokenDestination";
}
```