### PR TITLE
Correzione riferimento al workflow di build nel README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Java CI with Maven](https://github.com/italia/keycloak-spid-provider/actions/workflows/maven.yml/badge.svg)](https://github.com/italia/keycloak-spid-provider/actions/workflows/maven.yml)
+[![Java CI with Maven](https://github.com/italia/keycloak-spid-provider/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/italia/keycloak-spid-provider/actions/workflows/build-and-test.yml)
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/italia/keycloak-spid-provider?sort=semver)](https://img.shields.io/github/v/release/italia/keycloak-spid-provider?sort=semver) 
 [![GitHub All Releases](https://img.shields.io/github/downloads/italia/keycloak-spid-provider/total)](https://img.shields.io/github/downloads/italia/keycloak-spid-provider/total)
 [![GitHub issues](https://img.shields.io/github/issues/italia/keycloak-spid-provider)](https://github.com/italia/keycloak-spid-provider/issues)


### PR DESCRIPTION
Fix su link alla action build-and-test.yml, a seguito degli aggiornamenti risultava ancora puntato alla maven.yml che era stata rimossa.